### PR TITLE
rpc-test.osmosis.zone -> rpc.testnet.osmosis.zone

### DIFF
--- a/backend/.env_sample
+++ b/backend/.env_sample
@@ -1,5 +1,5 @@
 BLOCKCHAIN_REST_SERVER="https://lcd-test.osmosis.zone"
 FAUCET_MNEMONIC=""
 VALIDATOR_MNEMONIC=""
-RPC="https://rpc-test.osmosis.zone"
+RPC="https://rpc.testnet.osmosis.zone"
 SERVER_PORT=80

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -60,7 +60,7 @@
                // storage.setStorageSync("chainId", "osmo-test-1");
                 this.isTestnet = true;
                 this.chainId = "osmo-test-4";
-                this.rpcEndpoint = "https://rpc-test.osmosis.zone";
+                this.rpcEndpoint = "https://rpc.testnet.osmosis.zone";
 
             }else if(network == "mainnet") {
               //  storage.setStorageSync("chainId", "osmosis-1");

--- a/frontend/src/Network.vue
+++ b/frontend/src/Network.vue
@@ -37,7 +37,7 @@
 
                 if (network == "testnet"){
                     this.chainId = "osmo-test-4";
-                    this.rpcEndpoint = "https://rpc-test.osmosis.zone";
+                    this.rpcEndpoint = "https://rpc.testnet.osmosis.zone";
                 }else if(network == "mainnet") {
                     this.chainId = "osmosis-1";
                     this.rpcEndpoint = "https://rpc.osmosis.zone";

--- a/frontend/src/components/Keplr.vue
+++ b/frontend/src/components/Keplr.vue
@@ -76,7 +76,7 @@
                     await window.keplr.experimentalSuggestChain({
                         chainId: this.chainId,
                         chainName: "Osmosis Testnet",
-                        rpc: "https://rpc-test.osmosis.zone",
+                        rpc: "https://rpc.testnet.osmosis.zone",
                         rest: "https://lcd-test.osmosis.zone",
                         stakeCurrency: {
                             coinDenom: "OSMO",

--- a/frontend/src/stores/keplr.js
+++ b/frontend/src/stores/keplr.js
@@ -8,7 +8,7 @@ export const usekeplrStore = defineStore('keplr', {
     state: () => ({
         isNetworkAdded: false,
         chainId: 'osmo-test-4',
-        rpcEndpoint: 'https://rpc-test.osmosis.zone',
+        rpcEndpoint: 'https://rpc.testnet.osmosis.zone',
         address: null,
         resultTx: '',
         isTestnet: true,


### PR DESCRIPTION
faucet page is down... I don't have all the tooling setup to test if this fixes it, but I believe it's the redirect causing the error and this should do the trick